### PR TITLE
feat: add MapWithAI to list of available Tasking Managers

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -83,6 +83,14 @@ export class CONSTANTS {
       summaryAPI: "/queries/summary/",
       tag: "hotosm-id-project",
     },
+    "MapWithAI": {
+      abbreviatedOptions: "/?abbreviated=true",
+      apiURL:
+        "https://mwai-tasking-manager-production-api.mapwith.ai/api/v2/projects/",
+      projectURL: "https://tasks.mapwith.ai/projects",
+      summaryAPI: "/queries/summary/",
+      tag: "mapwithai-project",
+    },
     // NOT SAME TM => API doesn't work the same => https://github.com/hotosm/osm-tasking-manager2/wiki/API
     // "OSM Swiss": {
     //   abbreviatedOptions: "?abbreviated=true",


### PR DESCRIPTION
I have added in the MapWithAI Tasking Manager from Meta to the list of available TMs to choose from. This will be very helpful for multiple Youthmappers communities and other partners who are mapping pedestrian infrastructure using MapWithAI TM and Rapid 2.1 editor.